### PR TITLE
Fix: Switch build backend from setuptools to flit for PEP 517 compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.0.1] - 2024-06-18
+### Changed
+- Switched build backend from setuptools to flit for modern, PEP 517-compliant builds and installation using only pyproject.toml
+- **Motivation**: setuptools does not fully support installation using only pyproject.toml and still requires setup.py or setup.cfg for metadata
+
 ## [1.0.0] - 2024-06-18
 ### Added
 - Initial release of traceattrs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 authors = [{ name = "Alen Joe Antony", email = "alenjantony@gmail.com" }]
 requires-python = ">=3.9"
 license = "MIT"
-license-files = ["LICENSE.md"]
+license-files = ["LICENSE"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "traceattrs"
-version = "1.0.0"
+version = "1.0.1"
 description = "A lightweight Python library to automatically track changes to object attributes over time. Designed to monitor state changes without boilerplate or intrusive instrumentation."
 readme = "README.md"
 authors = [{ name = "Alen Joe Antony", email = "alenjantony@gmail.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools >= 77.0.3"]
-build-backend = "setuptools.build_meta"
+requires = ["flit_core >= 3.12.0, <4"]
+build-backend = "flit_core.buildapi"
 
 [project]
 name = "traceattrs"


### PR DESCRIPTION
This PR updates the build backend from `setuptools` to flit in `pyproject.toml` to enable modern, PEP 517-compliant builds and installation using only `pyproject.toml`.


**Motivation**

-  `setuptools` does not fully support installation with only `pyproject.toml`, causing pip install from git to fail with **UNKNOWN package name/version**.
- Now, pip install from git works as expected and installs the correct package and version.