### PR TITLE
Fix/issue 4 typo in changelog year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 
-## [1.0.1] - 2024-06-18
+## [1.0.1] - 2025-06-18
 ### Changed
 - Switched build backend from setuptools to flit for modern, PEP 517-compliant builds and installation using only pyproject.toml
 - **Motivation**: setuptools does not fully support installation using only pyproject.toml and still requires setup.py or setup.cfg for metadata
 
-## [1.0.0] - 2024-06-18
+## [1.0.0] - 2025-06-18
 ### Added
 - Initial release of traceattrs
 - Track changes to any attribute of class instances

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [1.0.1] - 2025-06-18
 ### Changed
+- Fixed typo in the changelog where the year was incorrecly listed as 2024 instead of 2025
 - Switched build backend from setuptools to flit for modern, PEP 517-compliant builds and installation using only pyproject.toml
 - **Motivation**: setuptools does not fully support installation using only pyproject.toml and still requires setup.py or setup.cfg for metadata
 


### PR DESCRIPTION
Fixed typo in the CHANGELOG.md file where the year was incorrectly listed as 2024 instead of 2025. (See issue #4)